### PR TITLE
client: Improved HTTP status code checking

### DIFF
--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -96,9 +96,23 @@ class version_tests(SimpleClientTestCase):
             self.assertEqual(versions['Arch'], 'amd64')
 
     @mock.patch('requests.get')
-    def test_version_httperror(self, get_mock):
+    def test_version_httperror_404(self, get_mock):
         get_mock.return_value = requests_mock.Response(
             '404 page not found\n', 404)
+        with self.assertRaises(ClientError):
+            self.client.version()
+
+    @mock.patch('requests.get')
+    def test_version_httperror_500(self, get_mock):
+        get_mock.return_value = requests_mock.Response(
+            '500 internal server error\n', 500)
+        with self.assertRaises(ServerError):
+            self.client.version()
+
+    @mock.patch('requests.get')
+    def test_version_httperror_unknown(self, get_mock):
+        get_mock.return_value = requests_mock.Response(
+            '999 foobar\n', 999)
         with self.assertRaises(HTTPError):
             self.client.version()
 


### PR DESCRIPTION
- Default to accepting all 2xx status codes as success.
- Raise ClientError exception for all 4xx status codes.
- Raise ServerError exception for all 5xx status codes.

Signed-off-by: Esben Haabendal esben@haabendal.dk
